### PR TITLE
Fix: #16. Cache-control must be detailed.

### DIFF
--- a/rules/cache-control-test.yml
+++ b/rules/cache-control-test.yml
@@ -1,0 +1,71 @@
+openapi: 3.0.1
+paths:
+  /ok-cache-control:
+    get:
+      parameters:
+      - name: Cache-Control
+        in: header
+        example: >-
+          max-age: 3000
+        description: |-
+          This rule should find a way to ensure that the API provider
+          analysed and documented all the issues of caching and
+          decided to use (eg. max-age, private, ...) because...
+        schema:
+          type: string
+      responses:
+        "201":
+          description: Cache-Control must contain a placeholder
+  /ko-cache-control-nodescription:
+    get:
+      parameters:
+      - name: Cache-Control
+        in: header
+        schema:
+          type: string
+      responses:
+        "201":
+          description: Should detail cache usage.
+
+  /ko-cache-control-short-description:
+    get:
+      parameters:
+      - name: Cache-Control
+        in: header
+        description: |-
+          Should detail cache usage
+        schema:
+          type: string
+      responses:
+        "201":
+          description: Should have a meaningful cache usage.
+
+  /ko-cache-control-and-expires:
+    get:
+      responses:
+        "201":
+          description: Cache-Control overrides Expires.
+          headers:
+            Cache-Control:
+              description: |-
+                max-age private no-store
+              schema:
+                type: string
+            Expires:
+                description: |-
+                  max-age private no-store
+
+  /ko-cache-control-and-expires-lower:
+    get:
+      responses:
+        "201":
+          description: Cache-Control overrides Expires.
+          headers:
+            cache-control:
+              description: |-
+                max-age private no-store
+              schema:
+                type: string
+            expires:
+                description: |-
+                  max-age private no-store

--- a/rules/cache-control-test.yml
+++ b/rules/cache-control-test.yml
@@ -52,7 +52,9 @@ paths:
           type: string
       responses:
         "201":
-          description: Should detail cache usage.
+          description: |-
+            Should detail cache usage. As `headers` is missing
+            other checks won't run on responses.
 
   /ko-cache-control-request-short-description:
     get:

--- a/rules/cache-control-test.yml
+++ b/rules/cache-control-test.yml
@@ -16,7 +16,34 @@ paths:
       responses:
         "201":
           description: Cache-Control must contain a placeholder
-  /ko-cache-control-nodescription:
+          headers:
+            Cache-Control:
+              example: >-
+                max-age: 3000
+              description: |-
+                This rule should find a way to ensure that the API provider
+                analysed and documented all the issues of caching and
+                decided to use (eg. max-age, private, ...) because...
+              schema:
+                type: string
+
+  /ok-cache-control-responses:
+    get:
+      responses:
+        "201":
+          description: Cache-Control must contain a placeholder
+          headers:
+            Cache-Control:
+              example: >-
+                max-age: 3000
+              description: |-
+                This rule should find a way to ensure that the API provider
+                analysed and documented all the issues of caching and
+                decided to use (eg. max-age, private, ...) because...
+              schema:
+                type: string
+
+  /ko-cache-control-request-nodescription:
     get:
       parameters:
       - name: Cache-Control
@@ -27,7 +54,7 @@ paths:
         "201":
           description: Should detail cache usage.
 
-  /ko-cache-control-short-description:
+  /ko-cache-control-request-short-description:
     get:
       parameters:
       - name: Cache-Control
@@ -69,3 +96,40 @@ paths:
             expires:
                 description: |-
                   max-age private no-store
+  /ko-no-cache-control-nor-expires:
+    get:
+      responses:
+        "201":
+          description: Cache-Control overrides Expires.
+  /ko-expires-nodescription:
+    get:
+      responses:
+        "201":
+          description: Cache-Control overrides Expires.
+          headers:
+            Expires:
+              description: ""
+  /ko-cache-control-response-nodescription:
+    get:
+      responses:
+        "201":
+          description: Cache-Control overrides Expires.
+          headers:
+            Cache-Control:
+              description: ""
+  /ko-expires-short-description:
+    get:
+      responses:
+        "201":
+          description: Cache-Control overrides Expires.
+          headers:
+            Expires:
+              description: "short description"
+  /ko-cache-control-response-short-description:
+    get:
+      responses:
+        "201":
+          description: Cache-Control overrides Expires.
+          headers:
+            Cache-Control:
+              description: "this is very short"

--- a/rules/cache-control.yml
+++ b/rules/cache-control.yml
@@ -1,0 +1,116 @@
+rules:
+  cache-control-undocumented:
+    description: |-
+      Cache usage MUST be extensively detailed in the `description` property
+      to avoid data leaks or the usage of stale data.
+
+      This rule should ensure in some way that the api provider
+      documented extensively the cache usage to avoid data leaks
+      or usage of stale data.
+
+      For now this just tests the presence of `max-age` but that's
+      only a placeholder. Hints welcome.
+    message: >-
+      Cache usage MUST be documented: {{error}} {{path}}
+    formats:
+      - oas3
+    severity: error
+    recommended: true
+    given: >-
+      $..[parameters].[?(@.name=="cache-control" || @.name=="Cache-Control")]
+    then:
+    -  field: description
+       function: truthy
+    -  field: description
+       function: pattern
+       functionOptions:
+         match: >-
+           (max-age|private|no-store|no-cache).*
+
+  expires-undocumented:
+    description: |-
+      Cache usage MUST be extensively detailed in the `description` property
+      to avoid data leaks or the usage of stale data.
+
+      This rule should ensure in some way that the api provider
+      documented extensively the cache usage to avoid data leaks
+      or usage of stale data.
+
+      For now this just tests the presence of `max-age` but that's
+      only a placeholder. Hints welcome.
+    message: >-
+      Cache usage MUST be documented: {{error}} {{path}}
+    formats:
+      - oas3
+    severity: error
+    recommended: true
+    given: >-
+      $..[parameters].[?(@.name=="expires" || @.name=="Expires")]
+    then:
+    -  field: description
+       function: truthy
+    -  field: description
+       function: pattern
+       functionOptions:
+         match: >-
+           (max-age|private|no-store|no-cache).*
+
+  expires-or-cache-control:
+    description: |-
+      Cache-Control overrides Expires when `max-age` is set.
+    message: >-
+      Cache-Control overrides Expires when `max-age` is set.. {{property}} {{error}} {{path}}
+    formats:
+      - oas3
+    severity: warn
+    recommended: true
+    given: >-
+      $.[responses][?(@property[0] == "2" )][headers]
+    then:
+    - functionOptions:
+        properties:
+        -  Cache-Control
+        -  Expires
+      function: xor
+    - functionOptions:
+        properties:
+        -  cache-control
+        -  expires
+      function: xor
+
+
+  beware-euristic-cache: &beware-euristic-cache
+    description: |-
+      If no Cache-Control or Expires are set, clients MAY use euristic cache.
+    message: >-
+      If no Cache-Control or Expires are set, clients MAY use euristic cache. {{property}} {{error}} {{path}}
+    formats:
+      - oas3
+    severity: info
+    recommended: true
+    given: >-
+      $.[responses][?(@property[0] == "2" )][headers]
+    then:
+    - functionOptions:
+        properties:
+        -  Cache-Control
+        -  Expires
+      function: or
+
+  beware-euristic-cache-lowercase:
+    description: |-
+      If no Cache-Control or Expires are set, clients MAY use euristic cache.
+    message: >-
+      If no Cache-Control or Expires are set, clients MAY use euristic cache. {{property}} {{error}} {{path}}
+    formats:
+      - oas3
+    severity: info
+    recommended: true
+    given: >-
+      $.[responses][?(@property[0] == "2" )][headers]
+    then:
+    - functionOptions:
+        properties:
+          - cache-control
+          - expires
+      function: xor

--- a/rules/cache-control.yml
+++ b/rules/cache-control.yml
@@ -45,7 +45,7 @@ rules:
     severity: warn
     recommended: true
     given: >-
-      $.[responses][?(@property[0] == "2" )][headers].[?(@property.match(/Cache-Control|Expires/))]]
+      $.[responses][?(@property[0] == "2" )][headers].[?(@property.match(/Cache-Control|Expires/i))]]
     then:
     -  field: description
        function: truthy
@@ -55,39 +55,25 @@ rules:
          match: >-
            .*(max-age|private|no-store|no-cache).*
 
-  expires-or-cache-control:
+  indeterminate-cache-behavior:
     description: |-
-      Cache-Control overrides Expires when `max-age` is set.
+      Note that:
+      - if no Cache-Control or Expires are set, clients MAY use euristic cache;
+      - Cache-Control overrides Expires when `max-age` is set.    
     message: >-
-      Cache-Control overrides Expires when `max-age` is set.. {{property}} {{error}} {{path}}
-    formats:
-      - oas3
-    severity: warn
-    recommended: true
-#      $.[responses][?(@property[0] == "2" )][headers]
-    given: >-
-      $.[responses][?(@property[0] == "2" )][headers][?(@property.match(/cache-control|expires/i))]^
-    then:
-    - function: schema
-      functionOptions:
-        schema:
-          properties:
-            Cache-Control:
-              type: object
-            Expires:
-              type: object
-
-
-  beware-euristic-cache: &beware-euristic-cache
-    description: |-
-      If no Cache-Control or Expires are set, clients MAY use euristic cache.
-    message: >-
-      If no Cache-Control or Expires are set, clients MAY use euristic cache. {{property}} {{error}} {{path}}
+      Note that
+       if no Cache-Control or Expires are set, clients MAY use euristic cache;
+       and that Cache-Control overrides Expires when `max-age` is set.
+       {{property}} {{error}} {{path}}
     formats:
       - oas3
     severity: info
     recommended: true
     given: >-
-      $.[responses][?(@property[0] == "2" )][headers][?(@property.match(/cache-control|expires/i))]
+      $.[responses][?(@property[0] == "2" )][headers]
     then:
-    - function: truthy
+    - function: xor
+      functionOptions:
+        properties:
+        -  Expires
+        -  Cache-Control

--- a/rules/cache-control.yml
+++ b/rules/cache-control.yml
@@ -1,5 +1,5 @@
 rules:
-  cache-control-parameter-undocumented:
+  cache-control-parameter-undocumented: &cache-control
     description: |-
       Cache usage SHOULD be extensively detailed in the `description` property
       to avoid data leaks or the usage of stale data.
@@ -8,10 +8,18 @@ rules:
       documented extensively the cache usage to avoid data leaks
       or usage of stale data.
 
-      For now this just tests the presence of `max-age` but that's
-      only a placeholder. Hints welcome.
+      For now this ruleset tests:
+      * the presence of following keywords
+        in the `description`: `max-age`, `private`, `no-store`, `no-cache`.
+      * that one and only one between Expires and Cache-Control is used.
+
+      `Cache-Control and `Expires` should not be used in conjuction,
+      because `Cache-Control` overrides `Expires` when `max-age` is set.
+      Instead if neither `Cache-Control` or `Expires` are set, clients MAY use euristic cache
+      like described in RFC7234.
+
     message: >-
-      Cache usage SHOULD be documented: {{error}} {{path}}
+      Cache usage SHOULD be documented when used.
     formats:
       - oas3
     severity: warn
@@ -28,43 +36,16 @@ rules:
            .*(max-age|private|no-store|no-cache).*
 
   cache-responses-undocumented:
-    description: |-
-      Cache usage SHOULD be extensively detailed in the `description` property
-      to avoid data leaks or the usage of stale data.
-
-      This rule should ensure in some way that the api provider
-      documented extensively the cache usage to avoid data leaks
-      or usage of stale data.
-
-      For now this just tests the presence of `max-age` but that's
-      only a placeholder. Hints welcome.
+    <<: *cache-control
     message: >-
-      Cache usage SHOULD be documented in Cache-Control and/or Expires: {{error}} {{path}}
-    formats:
-      - oas3
-    severity: warn
-    recommended: true
+      Cache usage in responses SHOULD be documented in Cache-Control and/or Expires.
     given: >-
       $.[responses][?(@property[0] == "2" )][headers].[?(@property.match(/Cache-Control|Expires/i))]]
-    then:
-    -  field: description
-       function: truthy
-    -  field: description
-       function: pattern
-       functionOptions:
-         match: >-
-           .*(max-age|private|no-store|no-cache).*
 
-  indeterminate-cache-behavior:
-    description: |-
-      Note that:
-      - if no Cache-Control or Expires are set, clients MAY use euristic cache;
-      - Cache-Control overrides Expires when `max-age` is set.    
+  cache-responses-indeterminate-behavior:
+    <<: *cache-control
     message: >-
-      Note that
-       if no Cache-Control or Expires are set, clients MAY use euristic cache;
-       and that Cache-Control overrides Expires when `max-age` is set.
-       {{property}} {{error}} {{path}}
+      {{error}}
     formats:
       - oas3
     severity: info

--- a/rules/cache-control.yml
+++ b/rules/cache-control.yml
@@ -37,8 +37,9 @@ rules:
 
   cache-responses-undocumented:
     <<: *cache-control
+    severity: info
     message: >-
-      Cache usage in responses SHOULD be documented in Cache-Control and/or Expires.
+      Cache usage in responses SHOULD be documented in Cache-Control and/or Expires. {{error}}
     given: >-
       $.[responses][?(@property[0] == "2" )][headers].[?(@property.match(/Cache-Control|Expires/i))]]
 
@@ -46,8 +47,6 @@ rules:
     <<: *cache-control
     message: >-
       {{error}}
-    formats:
-      - oas3
     severity: info
     recommended: true
     given: >-

--- a/rules/cache-control.yml
+++ b/rules/cache-control.yml
@@ -1,7 +1,7 @@
 rules:
-  cache-control-undocumented:
+  cache-control-parameter-undocumented:
     description: |-
-      Cache usage MUST be extensively detailed in the `description` property
+      Cache usage SHOULD be extensively detailed in the `description` property
       to avoid data leaks or the usage of stale data.
 
       This rule should ensure in some way that the api provider
@@ -11,13 +11,13 @@ rules:
       For now this just tests the presence of `max-age` but that's
       only a placeholder. Hints welcome.
     message: >-
-      Cache usage MUST be documented: {{error}} {{path}}
+      Cache usage SHOULD be documented: {{error}} {{path}}
     formats:
       - oas3
-    severity: error
+    severity: warn
     recommended: true
     given: >-
-      $..[parameters].[?(@.name=="cache-control" || @.name=="Cache-Control")]
+      $..[parameters][?(@.in == "header" && @.name.match(/Cache-Control/i))]
     then:
     -  field: description
        function: truthy
@@ -25,11 +25,11 @@ rules:
        function: pattern
        functionOptions:
          match: >-
-           (max-age|private|no-store|no-cache).*
+           .*(max-age|private|no-store|no-cache).*
 
-  expires-undocumented:
+  cache-responses-undocumented:
     description: |-
-      Cache usage MUST be extensively detailed in the `description` property
+      Cache usage SHOULD be extensively detailed in the `description` property
       to avoid data leaks or the usage of stale data.
 
       This rule should ensure in some way that the api provider
@@ -39,13 +39,13 @@ rules:
       For now this just tests the presence of `max-age` but that's
       only a placeholder. Hints welcome.
     message: >-
-      Cache usage MUST be documented: {{error}} {{path}}
+      Cache usage SHOULD be documented in Cache-Control and/or Expires: {{error}} {{path}}
     formats:
       - oas3
-    severity: error
+    severity: warn
     recommended: true
     given: >-
-      $..[parameters].[?(@.name=="expires" || @.name=="Expires")]
+      $.[responses][?(@property[0] == "2" )][headers].[?(@property.match(/Cache-Control|Expires/))]]
     then:
     -  field: description
        function: truthy
@@ -53,7 +53,7 @@ rules:
        function: pattern
        functionOptions:
          match: >-
-           (max-age|private|no-store|no-cache).*
+           .*(max-age|private|no-store|no-cache).*
 
   expires-or-cache-control:
     description: |-
@@ -64,19 +64,18 @@ rules:
       - oas3
     severity: warn
     recommended: true
+#      $.[responses][?(@property[0] == "2" )][headers]
     given: >-
-      $.[responses][?(@property[0] == "2" )][headers]
+      $.[responses][?(@property[0] == "2" )][headers][?(@property.match(/cache-control|expires/i))]^
     then:
-    - functionOptions:
-        properties:
-        -  Cache-Control
-        -  Expires
-      function: xor
-    - functionOptions:
-        properties:
-        -  cache-control
-        -  expires
-      function: xor
+    - function: schema
+      functionOptions:
+        schema:
+          properties:
+            Cache-Control:
+              type: object
+            Expires:
+              type: object
 
 
   beware-euristic-cache: &beware-euristic-cache
@@ -89,28 +88,6 @@ rules:
     severity: info
     recommended: true
     given: >-
-      $.[responses][?(@property[0] == "2" )][headers]
+      $.[responses][?(@property[0] == "2" )][headers][?(@property.match(/cache-control|expires/i))]
     then:
-    - functionOptions:
-        properties:
-        -  Cache-Control
-        -  Expires
-      function: or
-
-  beware-euristic-cache-lowercase:
-    description: |-
-      If no Cache-Control or Expires are set, clients MAY use euristic cache.
-    message: >-
-      If no Cache-Control or Expires are set, clients MAY use euristic cache. {{property}} {{error}} {{path}}
-    formats:
-      - oas3
-    severity: info
-    recommended: true
-    given: >-
-      $.[responses][?(@property[0] == "2" )][headers]
-    then:
-    - functionOptions:
-        properties:
-          - cache-control
-          - expires
-      function: xor
+    - function: truthy

--- a/rules/tests/cache-control-test.snapshot
+++ b/rules/tests/cache-control-test.snapshot
@@ -1,0 +1,2 @@
+No results with a severity of 'error' or higher found!
+

--- a/rules/tests/cache-control-test.yml
+++ b/rules/tests/cache-control-test.yml
@@ -1,4 +1,10 @@
 openapi: 3.0.1
+components:
+  schemas:
+    CacheControl:
+      type: string
+      pattern: >-
+        [a-z \-]+(=([a-z \-]+|"\w+"))?(,\s+[a-z \-]+(=([a-z \-]+|"\w+")))?
 paths:
   /ok-cache-control:
     get:
@@ -6,27 +12,39 @@ paths:
       - name: Cache-Control
         in: header
         example: >-
-          max-age: 3000
+          max-age=3000
         description: |-
           This rule should find a way to ensure that the API provider
           analysed and documented all the issues of caching and
           decided to use (eg. max-age, private, ...) because...
         schema:
-          type: string
+          $ref: "#/components/schemas/CacheControl"
       responses:
         "201":
           description: Cache-Control must contain a placeholder
           headers:
             Cache-Control:
               example: >-
-                max-age: 3000
+                max-age=3000
               description: |-
                 This rule should find a way to ensure that the API provider
                 analysed and documented all the issues of caching and
                 decided to use (eg. max-age, private, ...) because...
               schema:
-                type: string
-
+                $ref: "#/components/schemas/CacheControl"
+  /ok-no-cache:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              maxLength: 500
+              pattern: "[a-z]+"
+      responses:
+        "201":
+          description: no cache
+          headers: {}
   /ok-cache-control-responses:
     get:
       responses:
@@ -35,27 +53,25 @@ paths:
           headers:
             Cache-Control:
               example: >-
-                max-age: 3000
+                max-age=3000
               description: |-
                 This rule should find a way to ensure that the API provider
                 analysed and documented all the issues of caching and
                 decided to use (eg. max-age, private, ...) because...
               schema:
-                type: string
-
+                $ref: "#/components/schemas/CacheControl"
   /ko-cache-control-request-nodescription:
     get:
       parameters:
       - name: Cache-Control
         in: header
         schema:
-          type: string
+          $ref: "#/components/schemas/CacheControl"
       responses:
         "201":
           description: |-
             Should detail cache usage. As `headers` is missing
             other checks won't run on responses.
-
   /ko-cache-control-request-short-description:
     get:
       parameters:
@@ -64,7 +80,7 @@ paths:
         description: |-
           Should detail cache usage
         schema:
-          type: string
+          $ref: "#/components/schemas/CacheControl"
       responses:
         "201":
           description: Should have a meaningful cache usage.
@@ -79,7 +95,7 @@ paths:
               description: |-
                 max-age private no-store
               schema:
-                type: string
+                $ref: "#/components/schemas/CacheControl"
             Expires:
                 description: |-
                   max-age private no-store
@@ -94,7 +110,7 @@ paths:
               description: |-
                 max-age private no-store
               schema:
-                type: string
+                $ref: "#/components/schemas/CacheControl"
             expires:
                 description: |-
                   max-age private no-store
@@ -119,6 +135,8 @@ paths:
           headers:
             Cache-Control:
               description: ""
+              schema:
+                $ref: "#/components/schemas/CacheControl"
   /ko-expires-short-description:
     get:
       responses:
@@ -135,3 +153,5 @@ paths:
           headers:
             Cache-Control:
               description: "this is very short"
+              schemas:
+                $ref: "#/components/schemas/CacheControl"

--- a/rules/tests/cache-control-test.yml
+++ b/rules/tests/cache-control-test.yml
@@ -1,7 +1,19 @@
 openapi: 3.0.1
 components:
+  headers:
+    Cache-Control-Ok: &CacheControlOk
+      example: >-
+        max-age=3000
+      description: |-
+        This rule should find a way to ensure that the API provider
+        analysed and documented all the issues of caching and
+        decided to use (eg. max-age, private, ...) because...
+      schema:
+        $ref: "#/components/schemas/CacheControl"
+
   schemas:
     CacheControl:
+      description: "max-age public"
       type: string
       pattern: >-
         [a-z \-]+(=([a-z \-]+|"\w+"))?(,\s+[a-z \-]+(=([a-z \-]+|"\w+")))?
@@ -24,26 +36,17 @@ paths:
           description: Cache-Control must contain a placeholder
           headers:
             Cache-Control:
-              example: >-
-                max-age=3000
-              description: |-
-                This rule should find a way to ensure that the API provider
-                analysed and documented all the issues of caching and
-                decided to use (eg. max-age, private, ...) because...
-              schema:
-                $ref: "#/components/schemas/CacheControl"
-  /ok-no-cache:
+              $ref: '#/components/headers/Cache-Control-Ok'
+  /ok-no-headers:
     put:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-              maxLength: 500
-              pattern: "[a-z]+"
       responses:
         "201":
-          description: no cache
+          description: ignore cache checks because no headers
+  /ko-empty-headers:
+    put:
+      responses:
+        "201":
+          description: error as no cache in headers
           headers: {}
   /ok-cache-control-responses:
     get:
@@ -52,14 +55,8 @@ paths:
           description: Cache-Control must contain a placeholder
           headers:
             Cache-Control:
-              example: >-
-                max-age=3000
-              description: |-
-                This rule should find a way to ensure that the API provider
-                analysed and documented all the issues of caching and
-                decided to use (eg. max-age, private, ...) because...
-              schema:
-                $ref: "#/components/schemas/CacheControl"
+              $ref: '#/components/headers/Cache-Control-Ok'
+
   /ko-cache-control-request-nodescription:
     get:
       parameters:
@@ -92,13 +89,10 @@ paths:
           description: Cache-Control overrides Expires.
           headers:
             Cache-Control:
+              $ref: "#/components/schemas/CacheControl"
+            Expires:
               description: |-
                 max-age private no-store
-              schema:
-                $ref: "#/components/schemas/CacheControl"
-            Expires:
-                description: |-
-                  max-age private no-store
 
   /ko-cache-control-and-expires-lower:
     get:
@@ -107,10 +101,7 @@ paths:
           description: Cache-Control overrides Expires.
           headers:
             cache-control:
-              description: |-
-                max-age private no-store
-              schema:
-                $ref: "#/components/schemas/CacheControl"
+              <<: CacheControlOk
             expires:
                 description: |-
                   max-age private no-store
@@ -134,9 +125,8 @@ paths:
           description: Cache-Control overrides Expires.
           headers:
             Cache-Control:
+              <<: *CacheControlOk
               description: ""
-              schema:
-                $ref: "#/components/schemas/CacheControl"
   /ko-expires-short-description:
     get:
       responses:
@@ -152,6 +142,6 @@ paths:
           description: Cache-Control overrides Expires.
           headers:
             Cache-Control:
+              <<: *CacheControlOk
               description: "this is very short"
-              schemas:
-                $ref: "#/components/schemas/CacheControl"
+              


### PR DESCRIPTION
## This PR

Requires detailed information in cache-control.

      This rule should ensure in some way that the api provider
      documented extensively the cache usage to avoid data leaks
      or usage of stale data.
      
      For now this just tests the presence of `max-age` but that's
      only a placeholder. Hints welcome.


If cache-control is not specified, other headers may be used (e.g Expires, Last-Modified, ...) and in the end, User Agents may apply euristic caching. So the following questions arise:

- [ ] should we *MUST* Cache-Control ?
- [ ] should we check for `Expires` & `Last-Modified` too?