### PR TITLE
Improve examples color.

### DIFF
--- a/ruleset_doc_generator.mjs
+++ b/ruleset_doc_generator.mjs
@@ -62,6 +62,15 @@ const html = `<!DOCTYPE html>
     h3 {
         margin: 48px 0 24px 0;
     }
+    code, kbd {
+      color: white;
+      background-color: black;
+    }
+    pre {
+        color: white;
+        background-color: black;
+        padding: 20px !important;
+    }
     </style>
     <title>${title}</title>
 </head>


### PR DESCRIPTION
## This PR

shows examples in terminal-like colors (white on black)

cc: @fupete @bfabio color hints? Can you fix the CSS to use the Titillium fonts & Co?