### PR TITLE
chore: use redux hooks instead of hoc connect

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import './App.css';
-import Header from './components/Header.js';
-import Main from './components/Main.js';
+import { Header } from './components/Header.js';
+import { Main } from './components/Main.js';
 
 const App = () => (
   <>

--- a/src/components/ExportResultsButton.js
+++ b/src/components/ExportResultsButton.js
@@ -1,19 +1,19 @@
 import React, { useCallback } from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { Button } from 'design-react-kit';
 import { getRawValidationResults, isValidationInProgress } from '../redux/selectors.js';
 import { downloadFile } from '../utils.mjs';
-import { getValidationResultsPropTypes } from '../spectral/spectral_utils.js';
 
-const ExportResultsButton = ({ isValidationInProgress, validationResults }) => {
+export const ExportResultsButton = () => {
+  const validationInProgress = useSelector((state) => isValidationInProgress(state));
+  const validationResults = useSelector((state) => getRawValidationResults(state));
   const exportValidationResults = useCallback(() => {
     downloadFile(JSON.stringify(validationResults, null, 2), `oas-results-${new Date().toISOString()}.json`, 'json');
   }, [validationResults]);
   return (
     <Button
       color="custom-white"
-      disabled={isValidationInProgress || validationResults === null || validationResults.length === 0}
+      disabled={validationInProgress || validationResults === null || validationResults.length === 0}
       icon={false}
       tag="button"
       onClick={exportValidationResults}
@@ -22,13 +22,3 @@ const ExportResultsButton = ({ isValidationInProgress, validationResults }) => {
     </Button>
   );
 };
-
-ExportResultsButton.propTypes = {
-  isValidationInProgress: PropTypes.bool.isRequired,
-  validationResults: getValidationResultsPropTypes(),
-};
-
-export default connect((state) => ({
-  isValidationInProgress: isValidationInProgress(state),
-  validationResults: getRawValidationResults(state),
-}))(ExportResultsButton);

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { Icon } from 'design-react-kit';
 import { createUseStyles } from 'react-jss';
 import cx from 'classnames';
-import PropTypes from 'prop-types';
 import { toogleMenu } from '../redux/actions.js';
 import { isMenuDisplayed } from '../redux/selectors.js';
 
@@ -33,13 +32,15 @@ const useStyles = createUseStyles({
   },
 });
 
-const Header = ({ isMenuDisplayed, toogleMenu }) => {
+export const Header = () => {
   const classes = useStyles();
+  const showMenu = useSelector((state) => isMenuDisplayed(state));
+  const dispatch = useDispatch();
   const leftSection = cx(
     {
-      'col-lg-2 col-xxl-1': isMenuDisplayed,
-      'col-lg-1 col-xxl-1': !isMenuDisplayed,
-      'bg-white': isMenuDisplayed,
+      'col-lg-2 col-xxl-1': showMenu,
+      'col-lg-1 col-xxl-1': !showMenu,
+      'bg-white': showMenu,
     },
     'd-flex',
     'align-items-center',
@@ -49,8 +50,8 @@ const Header = ({ isMenuDisplayed, toogleMenu }) => {
 
   const rightSection = cx(
     {
-      'col-lg-10 col-xxl-11': isMenuDisplayed,
-      'col-lg-11 col-xxl-11': !isMenuDisplayed,
+      'col-lg-10 col-xxl-11': showMenu,
+      'col-lg-11 col-xxl-11': !showMenu,
     },
     'd-flex',
     'justify-content-center',
@@ -62,8 +63,8 @@ const Header = ({ isMenuDisplayed, toogleMenu }) => {
 
   const iconClassNames = cx(
     {
-      'icon-white': !isMenuDisplayed,
-      'icon-primary': isMenuDisplayed,
+      'icon-white': !showMenu,
+      'icon-primary': showMenu,
     },
     'ml-4',
     classes.icon
@@ -75,7 +76,7 @@ const Header = ({ isMenuDisplayed, toogleMenu }) => {
         <div className={`row no-gutters bg-primary text-white`}>
           <div className={leftSection}>
             <Icon
-              onClick={toogleMenu}
+              onClick={() => dispatch(toogleMenu())}
               role="button"
               className={iconClassNames}
               icon="it-burger"
@@ -101,10 +102,3 @@ const Header = ({ isMenuDisplayed, toogleMenu }) => {
     </header>
   );
 };
-
-Header.propTypes = {
-  isMenuDisplayed: PropTypes.bool.isRequired,
-  toogleMenu: PropTypes.func.isRequired,
-};
-
-export default connect((state) => ({ isMenuDisplayed: isMenuDisplayed(state) }), { toogleMenu })(Header);

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { render, screen, fireEvent } from '../test-utils.js';
-import Header from './Header.js';
+import { Header } from './Header.js';
 
 describe('Header', () => {
   it('renders an header', () => {

--- a/src/components/LoadFromUrlButton.js
+++ b/src/components/LoadFromUrlButton.js
@@ -1,20 +1,21 @@
 import React, { useCallback, useState } from 'react';
 import { Button, Input, Modal, ModalBody, ModalFooter, ModalHeader } from 'design-react-kit';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { useSelector, useDispatch } from 'react-redux';
 import { setDocumentUrl, resetValidationResults } from '../redux/actions.js';
 import { isValidationInProgress } from '../redux/selectors.js';
 import useModalView from './useModalView.js';
 
-const LoadFromUrlButton = ({ isValidationInProgress, setDocumentUrl, resetValidationResults }) => {
+export const LoadFromUrlButton = () => {
+  const validationInProgress = useSelector((state) => isValidationInProgress(state));
+  const dispatch = useDispatch();
   const [isModalOpen, closeModal, openModal] = useModalView();
   const [url, setUrl] = useState('');
 
   const handleConfirmAction = useCallback(() => {
-    setDocumentUrl(url);
-    resetValidationResults();
+    dispatch(setDocumentUrl(url));
+    dispatch(resetValidationResults());
     closeModal();
-  }, [url, setDocumentUrl, resetValidationResults, closeModal]);
+  }, [url, closeModal, dispatch]);
 
   const handleOnChange = useCallback((e) => {
     setUrl(e.target.value);
@@ -22,7 +23,7 @@ const LoadFromUrlButton = ({ isValidationInProgress, setDocumentUrl, resetValida
 
   return (
     <>
-      <Button onClick={openModal} color="custom-white" disabled={isValidationInProgress} icon={false} tag="button">
+      <Button onClick={openModal} color="custom-white" disabled={validationInProgress} icon={false} tag="button">
         From url
       </Button>
 
@@ -42,19 +43,3 @@ const LoadFromUrlButton = ({ isValidationInProgress, setDocumentUrl, resetValida
     </>
   );
 };
-
-LoadFromUrlButton.propTypes = {
-  isValidationInProgress: PropTypes.bool.isRequired,
-  setDocumentUrl: PropTypes.func.isRequired,
-  resetValidationResults: PropTypes.func.isRequired,
-};
-
-export default connect(
-  (state) => ({
-    isValidationInProgress: isValidationInProgress(state),
-  }),
-  {
-    setDocumentUrl,
-    resetValidationResults,
-  }
-)(LoadFromUrlButton);

--- a/src/components/LoadTemplateButton.js
+++ b/src/components/LoadTemplateButton.js
@@ -1,36 +1,21 @@
 import React, { useCallback } from 'react';
 import { Button } from 'design-react-kit';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { useSelector, useDispatch } from 'react-redux';
 import { setDocumentUrl, resetValidationResults } from '../redux/actions.js';
 import { isValidationInProgress } from '../redux/selectors.js';
 import { TEMPLATE_DOCUMENT_URL } from '../utils.mjs';
 
-const LoadTemplateButton = ({ isValidationInProgress, setDocumentUrl, resetValidationResults }) => {
+export const LoadTemplateButton = () => {
+  const validationInProgress = useSelector((state) => isValidationInProgress(state));
+  const dispatch = useDispatch();
   const handleOnClick = useCallback(() => {
-    setDocumentUrl(TEMPLATE_DOCUMENT_URL);
-    resetValidationResults();
-  }, [setDocumentUrl, resetValidationResults]);
+    dispatch(setDocumentUrl(TEMPLATE_DOCUMENT_URL));
+    dispatch(resetValidationResults());
+  }, [dispatch]);
 
   return (
-    <Button onClick={handleOnClick} color="custom-white" disabled={isValidationInProgress} icon={false} tag="button">
+    <Button onClick={handleOnClick} color="custom-white" disabled={validationInProgress} icon={false} tag="button">
       Template
     </Button>
   );
 };
-
-LoadTemplateButton.propTypes = {
-  isValidationInProgress: PropTypes.bool.isRequired,
-  setDocumentUrl: PropTypes.func.isRequired,
-  resetValidationResults: PropTypes.func.isRequired,
-};
-
-export default connect(
-  (state) => ({
-    isValidationInProgress: isValidationInProgress(state),
-  }),
-  {
-    setDocumentUrl,
-    resetValidationResults,
-  }
-)(LoadTemplateButton);

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,15 +1,14 @@
 import React, { Suspense } from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import cx from 'classnames';
-import PropTypes from 'prop-types';
 import { createUseStyles } from 'react-jss';
 import { Spinner } from 'design-react-kit';
 import { isMenuDisplayed } from '../redux/selectors.js';
-import Menu from './Menu.js';
-import ValidationController from './ValidationController.js';
-import ValidationSummary from './ValidationSummary.js';
-import ValidationResults from './ValidationResults.js';
-import RulesetSelect from './RulesetSelect.js';
+import { Menu } from './Menu.js';
+import { ValidationController } from './ValidationController.js';
+import { ValidationSummary } from './ValidationSummary.js';
+import { ValidationResults } from './ValidationResults.js';
+import { RulesetSelect } from './RulesetSelect.js';
 
 // Lazy load editor to gain some ms on the fcp
 const Editor = React.lazy(() => import('./Editor.js'));
@@ -45,21 +44,22 @@ const useStyles = createUseStyles({
   },
 });
 
-const Main = ({ isMenuDisplayed }) => {
+export const Main = () => {
   const classes = useStyles();
+  const showMenu = useSelector((state) => isMenuDisplayed(state));
 
   const leftSection = cx(
     {
-      'col-lg-2 col-xxl-1': isMenuDisplayed,
-      [classes['col-0']]: !isMenuDisplayed,
+      'col-lg-2 col-xxl-1': showMenu,
+      [classes['col-0']]: !showMenu,
     },
     classes.animate
   );
 
   const editorSection = cx(
     {
-      'col-lg-6 col-xxl-7': isMenuDisplayed,
-      'col-lg-8': !isMenuDisplayed,
+      'col-lg-6 col-xxl-7': showMenu,
+      'col-lg-8': !showMenu,
     },
     classes.editor
   );
@@ -91,9 +91,3 @@ const Main = ({ isMenuDisplayed }) => {
     </main>
   );
 };
-
-Main.propTypes = {
-  isMenuDisplayed: PropTypes.bool.isRequired,
-};
-
-export default connect((state) => ({ isMenuDisplayed: isMenuDisplayed(state) }))(Main);

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { createUseStyles } from 'react-jss';
-import LoadFromUrlButton from './LoadFromUrlButton.js';
-import UploadFileButton from './UploadFileButton.js';
-import ExportResultsButton from './ExportResultsButton.js';
-import SaveFileButton from './SaveFileButton.js';
-import LoadTemplateButton from './LoadTemplateButton.js';
+import { LoadFromUrlButton } from './LoadFromUrlButton.js';
+import { UploadFileButton } from './UploadFileButton.js';
+import { ExportResultsButton } from './ExportResultsButton.js';
+import { SaveFileButton } from './SaveFileButton.js';
+import { LoadTemplateButton } from './LoadTemplateButton.js';
 
 const useStyles = createUseStyles({
   buttonContainer: {
@@ -22,7 +22,7 @@ const useStyles = createUseStyles({
   },
 });
 
-const Menu = () => {
+export const Menu = () => {
   const classes = useStyles();
 
   return (
@@ -49,5 +49,3 @@ const Menu = () => {
     </>
   );
 };
-
-export default Menu;

--- a/src/components/Menu.test.js
+++ b/src/components/Menu.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, screen } from '../test-utils.js';
 import { DEFAULT_RULESET } from '../utils.mjs';
-import Menu from './Menu.js';
+import { Menu } from './Menu.js';
 
 describe('menu', () => {
   it('renders Menu', () => {

--- a/src/components/RulesetSelect.js
+++ b/src/components/RulesetSelect.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { useSelector, useDispatch } from 'react-redux';
 import { createUseStyles } from 'react-jss';
 import { Icon } from 'design-react-kit';
 import { isValidationInProgress, getRuleset } from '../redux/selectors.js';
@@ -35,15 +34,18 @@ const useStyles = createUseStyles({
   },
 });
 
-const RulesetSelect = ({ isValidationInProgress, ruleset, setRuleset }) => {
+export const RulesetSelect = () => {
+  const validationInProgress = useSelector((state) => isValidationInProgress(state));
+  const ruleset = useSelector((state) => getRuleset(state));
+  const dispatch = useDispatch();
   const classes = useStyles();
   return (
     <div className="pt-3 d-flex align-items-center bg-white">
       <select
         className={classes.select}
-        disabled={isValidationInProgress}
+        disabled={validationInProgress}
         value={ruleset}
-        onChange={(e) => setRuleset(e.target.value)}
+        onChange={(e) => dispatch(setRuleset(e.target.value))}
       >
         <option value={RULESET_ITALIAN}>Italian API Guidelines</option>
         <option value={RULESET_BEST_PRACTICES}>Best Practices Only</option>
@@ -57,19 +59,3 @@ const RulesetSelect = ({ isValidationInProgress, ruleset, setRuleset }) => {
     </div>
   );
 };
-
-RulesetSelect.propTypes = {
-  isValidationInProgress: PropTypes.bool.isRequired,
-  ruleset: PropTypes.string.isRequired,
-  setRuleset: PropTypes.func.isRequired,
-};
-
-export default connect(
-  (state) => ({
-    isValidationInProgress: isValidationInProgress(state),
-    ruleset: getRuleset(state),
-  }),
-  {
-    setRuleset,
-  }
-)(RulesetSelect);

--- a/src/components/SaveFileButton.js
+++ b/src/components/SaveFileButton.js
@@ -1,18 +1,19 @@
 import React, { useCallback } from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { Button } from 'design-react-kit';
 import { getDocumentText, isValidationInProgress } from '../redux/selectors.js';
 import { downloadFile } from '../utils.mjs';
 
-const SaveFileButton = ({ isValidationInProgress, documentText }) => {
+export const SaveFileButton = () => {
+  const validationInProgress = useSelector((state) => isValidationInProgress(state));
+  const documentText = useSelector((state) => getDocumentText(state));
   const saveFile = useCallback(() => {
     downloadFile(documentText, `api-spec-${new Date().toISOString()}.yaml`, 'yaml');
   }, [documentText]);
   return (
     <Button
       color="custom-white"
-      disabled={isValidationInProgress || documentText === ''}
+      disabled={validationInProgress || documentText === ''}
       icon={false}
       tag="button"
       onClick={saveFile}
@@ -21,13 +22,3 @@ const SaveFileButton = ({ isValidationInProgress, documentText }) => {
     </Button>
   );
 };
-
-SaveFileButton.propTypes = {
-  isValidationInProgress: PropTypes.bool.isRequired,
-  documentText: PropTypes.string,
-};
-
-export default connect((state) => ({
-  isValidationInProgress: isValidationInProgress(state),
-  documentText: getDocumentText(state),
-}))(SaveFileButton);

--- a/src/components/UploadFileButton.js
+++ b/src/components/UploadFileButton.js
@@ -1,27 +1,28 @@
 import React, { useCallback } from 'react';
-import { connect } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import cx from 'classnames';
-import PropTypes from 'prop-types';
 import { setDocumentUrl, resetValidationResults } from '../redux/actions.js';
 import { isValidationInProgress } from '../redux/selectors.js';
 
-const UploadFileButton = ({ isValidationInProgress, setDocumentUrl, resetValidationResults }) => {
+export const UploadFileButton = () => {
+  const validationInProgress = useSelector((state) => isValidationInProgress(state));
+  const dispatch = useDispatch();
   const loadFile = useCallback(
     (e) => {
       const file = e.target.files[0];
       const reader = new FileReader();
       reader.onload = (loadedEvent) => {
-        setDocumentUrl(loadedEvent.target.result);
-        resetValidationResults();
+        dispatch(setDocumentUrl(loadedEvent.target.result));
+        dispatch(resetValidationResults());
       };
       reader.readAsDataURL(file);
     },
-    [setDocumentUrl, resetValidationResults]
+    [dispatch]
   );
 
   const labelAsButton = cx(
     {
-      disabled: isValidationInProgress,
+      disabled: validationInProgress,
     },
     ['btn', 'btn-custom-white']
   );
@@ -32,19 +33,3 @@ const UploadFileButton = ({ isValidationInProgress, setDocumentUrl, resetValidat
     </label>
   );
 };
-
-UploadFileButton.propTypes = {
-  isValidationInProgress: PropTypes.bool.isRequired,
-  setDocumentUrl: PropTypes.func.isRequired,
-  resetValidationResults: PropTypes.func.isRequired,
-};
-
-export default connect(
-  (state) => ({
-    isValidationInProgress: isValidationInProgress(state),
-  }),
-  {
-    setDocumentUrl,
-    resetValidationResults,
-  }
-)(UploadFileButton);

--- a/src/components/ValidationController.test.js
+++ b/src/components/ValidationController.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { render, screen, fireEvent } from '../test-utils.js';
-import ValidationController from './ValidationController.js';
+import { ValidationController } from './ValidationController.js';
 
 describe('ValidationController', () => {
   // TODO mock redux dispatch

--- a/src/components/ValidationResultItem.js
+++ b/src/components/ValidationResultItem.js
@@ -1,10 +1,9 @@
 import React, { useCallback, useMemo } from 'react';
 import { createUseStyles } from 'react-jss';
-import PropTypes from 'prop-types';
 import cx from 'classnames';
 import DOMPurify from 'dompurify';
 import marked from 'marked';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { Button, Icon, Modal, ModalBody, ModalFooter, ModalHeader } from 'design-react-kit';
 import { ERROR, WARNING, autoLinkRFC } from '../utils.mjs';
 import { focusDocumentLine } from '../redux/actions.js';
@@ -70,7 +69,8 @@ const useStyle = createUseStyles({
   },
 });
 
-const ValidationResultItem = ({ resultItem, focusDocumentLine }) => {
+export const ValidationResultItem = ({ resultItem }) => {
+  const dispatch = useDispatch();
   const classes = useStyle(resultItem);
   const [isModalOpen, closeModal, openModal] = useModalView();
 
@@ -83,8 +83,10 @@ const ValidationResultItem = ({ resultItem, focusDocumentLine }) => {
   );
 
   const handleOnResultClick = useCallback(() => {
-    focusDocumentLine({ line: getValidationResultLine(resultItem), character: resultItem.range.start.character });
-  }, [resultItem, focusDocumentLine]);
+    dispatch(
+      focusDocumentLine({ line: getValidationResultLine(resultItem), character: resultItem.range.start.character })
+    );
+  }, [resultItem, dispatch]);
 
   const handleOnAskSlackButtonClick = useCallback(() => {
     window.open('https://slack.developers.italia.it/');
@@ -145,9 +147,4 @@ const ValidationResultItem = ({ resultItem, focusDocumentLine }) => {
 
 ValidationResultItem.propTypes = {
   resultItem: getValidationResultItemPropTypes(),
-  focusDocumentLine: PropTypes.func.isRequired,
 };
-
-export default connect(null, {
-  focusDocumentLine,
-})(ValidationResultItem);

--- a/src/components/ValidationResultItem.test.js
+++ b/src/components/ValidationResultItem.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, screen } from '../test-utils.js';
 import { validationResultsMock } from '../mocks/validationResultsMock.js';
-import ValidationResultItem from './ValidationResultItem.js';
+import { ValidationResultItem } from './ValidationResultItem.js';
 
 describe('ValidationResultItem', () => {
   it('renders a result message', () => {

--- a/src/components/ValidationResults.js
+++ b/src/components/ValidationResults.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { createUseStyles } from 'react-jss';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { getValidationResults } from '../redux/selectors.js';
-import { getValidationResultsPropTypes, getValidationResultKey } from '../spectral/spectral_utils.js';
-import ValidationResultItem from './ValidationResultItem.js';
+import { getValidationResultKey } from '../spectral/spectral_utils.js';
+import { ValidationResultItem } from './ValidationResultItem.js';
 
 const useStyle = createUseStyles({
   enableScrollResults: { height: 'calc(100vh - 376px)', overflow: 'scroll' },
@@ -15,7 +15,8 @@ const useStyle = createUseStyles({
   },
 });
 
-const ValidationResults = ({ validationResults }) => {
+export const ValidationResults = () => {
+  const validationResults = useSelector((state) => getValidationResults(state));
   const classes = useStyle();
 
   if (validationResults === null || validationResults.length === 0) {
@@ -37,11 +38,3 @@ const ValidationResults = ({ validationResults }) => {
     </>
   );
 };
-
-ValidationResults.propTypes = {
-  validationResults: getValidationResultsPropTypes(),
-};
-
-export default connect((state) => ({
-  validationResults: getValidationResults(state),
-}))(ValidationResults);

--- a/src/components/ValidationResults.test.js
+++ b/src/components/ValidationResults.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, screen } from '../test-utils.js';
 import { validationResultsMock } from '../mocks/validationResultsMock.js';
-import ValidationResults from './ValidationResults.js';
+import { ValidationResults } from './ValidationResults.js';
 
 describe('ValidationResults', () => {
   it(`doesn't render nothing on init`, () => {

--- a/src/components/ValidationSummary.js
+++ b/src/components/ValidationSummary.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Badge } from 'design-react-kit';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { createUseStyles } from 'react-jss';
 import { getValidationResults } from '../redux/selectors.js';
 import { ERROR, WARNING } from '../utils.mjs';
-import { getValidationResultsPropTypes, getValidationResultType } from '../spectral/spectral_utils.js';
+import { getValidationResultType } from '../spectral/spectral_utils.js';
 
 const useStyles = createUseStyles({
   error: {
@@ -21,7 +21,8 @@ const getErrorLabel = (summary) => (summary.errors > 0 ? `${summary.errors} erro
 
 const getWarningLabel = (summary) => (summary.warnings > 0 ? `${summary.warnings} warnings` : 'No warnings');
 
-const ValidationSummary = ({ validationResults }) => {
+export const ValidationSummary = () => {
+  const validationResults = useSelector((state) => getValidationResults(state));
   const summary = {
     errors: validationResults?.filter((r) => getValidationResultType(r.severity) === ERROR).length,
     warnings: validationResults?.filter((r) => getValidationResultType(r.severity) === WARNING).length,
@@ -45,11 +46,3 @@ const ValidationSummary = ({ validationResults }) => {
     )
   );
 };
-
-ValidationSummary.propTypes = {
-  validationResults: getValidationResultsPropTypes(),
-};
-
-export default connect((state) => ({
-  validationResults: getValidationResults(state),
-}))(ValidationSummary);

--- a/src/components/ValidationSummary.test.js
+++ b/src/components/ValidationSummary.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, screen } from '../test-utils.js';
 import { validationResultsMock } from '../mocks/validationResultsMock.js';
-import ValidationSummary from './ValidationSummary.js';
+import { ValidationSummary } from './ValidationSummary.js';
 
 describe('ValidationSummary', () => {
   it('renders a validation summary', () => {


### PR DESCRIPTION
# This PR

Improves the code readability using hooks instead of the hoc connect function.

This is only pure code refactoring. No capabilities, performance, or usability are impacted.