### PR TITLE
Avoid http methods in paths. See #173

### DIFF
--- a/rules/paths.yml
+++ b/rules/paths.yml
@@ -54,3 +54,76 @@ rules:
       field: 'properties.title'
     - function: truthy
       field: 'properties.detail'
+  paths-http-method:
+    x-tags:
+      - it
+    description: |-
+      When you design a REST API, you don't usually need to mention terms like
+      `get`, `delete` and so on in your `paths`, because this information is
+      conveyed by the HTTP method.
+
+      Instead of using
+
+      ```
+      POST /books/1234/delete HTTP/1.1
+      Host: api.example
+      ```
+
+      You can simply call
+
+      ```
+      DELETE /books/1234 HTTP/1.1
+      Host: api.example
+      ```
+
+      Similarly you don't need verbs like `list` or `create` because
+      the HTTP Semantics RFC7231 supports this kind of actions natively
+      with proper methods and status code.
+
+      Instead of
+
+      ```
+      POST /create/user HTTP/1.1
+      Host: api.example
+      Content-Type: application/json
+
+      {"given_name": "Mario"}
+      ```
+
+      You can use
+      ```
+      POST /create/user HTTP/1.1
+      Host: api.example
+      Content-Type: application/json
+
+      {"given_name": "Mario"}
+      ```
+
+      returning a proper response
+
+      ```
+      HTTP/1.1 201 Created
+      Location: /users/1234
+
+      ```
+
+      This simplifies securing your API as you know beforehand the kind of action
+      which is going to be performed.
+    message: >-
+      API "path" contains a name of an http method. {{error}}
+    severity: hint
+    recommended: true
+    given:
+      - >-
+        $.paths[?(@property.match(
+        /\/(get|post|put|delete|patch)[\/A-Z_\-]?/
+        ))]~
+      - >-
+        $.paths[?(@property.match(
+        /\/(create|remove|list)[\/A-Z_\-]?/
+        ))]~
+
+    then:
+      field: "@key"
+      function: undefined
+

--- a/rules/tests/paths-test.snapshot
+++ b/rules/tests/paths-test.snapshot
@@ -4,6 +4,12 @@ OpenAPI 3.x detected
  19:28  warning  paths-status-problem-schema  `properties.detail` property is not truthy #/paths/~1status/get/responses/200/content/application~1problem+json/schema/properties  paths./status.get.responses[200].content.application/problem+json.schema.properties
  24:33    error  paths-status-return-problem  application/ko+json does not equal to one of application/problem+xml,application/problem+json                                      paths./status.get.responses[200].content.application/ko+json
  25:22  warning  paths-status-problem-schema  `schema.properties.status` property is not truthy #/paths/~1status/get/responses/200/content/application~1ko+json/schema           paths./status.get.responses[200].content.application/ko+json.schema
+ 27:11     hint  paths-http-method            API "path" contains a name of an http method. `/ko/get` property should be undefined                                               paths./ko/get
+ 28:12     hint  paths-http-method            API "path" contains a name of an http method. `/ko/post` property should be undefined                                              paths./ko/post
+ 29:15     hint  paths-http-method            API "path" contains a name of an http method. `/ko/getUser` property should be undefined                                           paths./ko/getUser
+ 30:16     hint  paths-http-method            API "path" contains a name of an http method. `/ko/get_user` property should be undefined                                          paths./ko/get_user
+ 31:16     hint  paths-http-method            API "path" contains a name of an http method. `/ko/get/user` property should be undefined                                          paths./ko/get/user
+ 32:18     hint  paths-http-method            API "path" contains a name of an http method. `/ko/patch/user` property should be undefined                                        paths./ko/patch/user
 
-✖ 3 problems (1 error, 2 warnings, 0 infos, 0 hints)
+✖ 9 problems (1 error, 2 warnings, 0 infos, 6 hints)
 

--- a/rules/tests/paths-test.yml
+++ b/rules/tests/paths-test.yml
@@ -24,3 +24,9 @@ paths:
             application/ko+json:
               schema:
                 type: string
+  /ko/get: {}
+  /ko/post: {}
+  /ko/getUser: {}
+  /ko/get_user: {}
+  /ko/get/user: {}
+  /ko/patch/user: {}


### PR DESCRIPTION
## This PR

suggests avoiding http methods in API paths, eg.

/foo/get/user
/foo/getUser
/foo/createUser ...