### PR TITLE
chore: remove immer forced resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,6 @@
   "license": "AGPL-3.0",
   "name": "api-oas-checker",
   "repository": "https://github.com/italia/api-oas-checker",
-  "resolutions": {
-    "immer": "^8.0.1"
-  },
   "scripts": {
     "build": "make all",
     "build-js": "NODE_ENV=production webpack",


### PR DESCRIPTION
# This PR

Removes the forced resolution of `immer`. It is no needed anymore since spectral version 5.8.1 (https://github.com/stoplightio/spectral/issues/1499)