### PR TITLE
feat(319-relative-security-urls): Allow relative urls in securitySche…

### DIFF
--- a/security/securitySchemes.yml
+++ b/security/securitySchemes.yml
@@ -119,9 +119,9 @@ rules:
   # OAuth2 specific
   securitySchemes-oauth-http:
     description: |-
-      OAuth2 endpoints must use `https://`
+      OAuth2 endpoints must use `https://` or be relative.
     message: >-
-      OAuth endpoints must use https://
+      OAuth endpoints must use https:// or be relative.
     formats:
       - oas3
     severity: error
@@ -134,7 +134,7 @@ rules:
         function: pattern
         functionOptions:
           match: >-
-            ^https://
+            ^(https://|/[^/])
   securitySchemes-oauth-allowed-flows:
     description: |-
       The OAuth2 authorization framework defines various

--- a/security/tests/securitySchemes-test.snapshot
+++ b/security/tests/securitySchemes-test.snapshot
@@ -10,9 +10,10 @@ OpenAPI 3.x detected
  46:20      warning  securitySchemes-oauth                JWT usage should be detailed in `description` must match the pattern '.*RFC8725.*'.                                                       components.securitySchemes.MyOauth2_ko.description
  47:18      warning  securitySchemes-jwt                  JWT usage should be detailed in `description` `JWTBearer_ko.description` property is not truthy.                                          components.securitySchemes.JWTBearer_ko
  53:20      warning  securitySchemes-jwt                  JWT usage should be detailed in `description` must match the pattern '.*RFC8725.*'.                                                       components.securitySchemes.JWTBearer2_ko.description
- 66:31        error  securitySchemes-oauth-http           OAuth endpoints must use https://                                                                                                         components.securitySchemes.MyOauth_ko3.flows.authorizationCode.authorizationUrl
+ 66:31        error  securitySchemes-oauth-http           OAuth endpoints must use https:// or be relative.                                                                                         components.securitySchemes.MyOauth_ko3.flows.authorizationCode.authorizationUrl
  67:20        error  securitySchemes-oauth-allowed-flows  Do not use oauth2 insecure flow: "implicit".                                                                                              components.securitySchemes.MyOauth_ko3.flows.implicit
  69:20        error  securitySchemes-oauth-allowed-flows  Do not use oauth2 insecure flow: "password".                                                                                              components.securitySchemes.MyOauth_ko3.flows.password
+ 72:23        error  securitySchemes-oauth-http           OAuth endpoints must use https:// or be relative.                                                                                         components.securitySchemes.MyOauth_ko3.flows.clientCredentials.tokenUrl
 
-✖ 12 problems (7 errors, 4 warnings, 1 info, 0 hints)
+✖ 13 problems (8 errors, 4 warnings, 1 info, 0 hints)
 

--- a/security/tests/securitySchemes-test.yml
+++ b/security/tests/securitySchemes-test.yml
@@ -68,3 +68,7 @@ components:
           "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize"
         "password":
           "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize"
+        "clientCredentials":
+          "tokenUrl": "non-relative-url"
+        "clientCredentials2":
+          "tokenUrl": "/relative-url"


### PR DESCRIPTION
…mes-oauth-http

Allows now `https://` (as before) well as relative urls like `/token` (new).
Relative URLs must start with a `/`.

Fixes https://github.com/italia/api-oas-checker/issues/319