### PR TITLE
Fix: #326. Support oas files with empty paths.

### DIFF
--- a/rules/paths.yml
+++ b/rules/paths.yml
@@ -13,10 +13,21 @@ rules:
       The "/status" path used to health-check the API must be defined. {{error}}
     severity: error
     recommended: true
-    given: $
+    given: $.paths
     then:
-      field: "paths./status.get.responses.200"
-      function: truthy
+      function: schema
+      functionOptions:
+        schema:
+          oneOf:
+          - type: object
+            required:
+            - "/status"
+            properties:
+              "/status":
+                type: object
+          - type: object
+            additionalProperties: false
+
   paths-status-return-problem:
     description: |-
       "/status" must return a Problem object.

--- a/rules/tests/paths-1-test.yml
+++ b/rules/tests/paths-1-test.yml
@@ -1,0 +1,9 @@
+openapi: 3.0.1
+tags: []
+servers: []
+info: {}
+paths: {}
+components:
+  schemas:
+    Foo:
+      type: string

--- a/rules/tests/paths-test.snapshot
+++ b/rules/tests/paths-test.snapshot
@@ -1,4 +1,5 @@
 OpenAPI 3.x detected
+OpenAPI 3.x detected
 
 /code/rules/tests/paths-test.yml
  19:28  warning  paths-status-problem-schema  `properties.detail` property is not truthy #/paths/~1status/get/responses/200/content/application~1problem+json/schema/properties  paths./status.get.responses[200].content.application/problem+json.schema.properties

--- a/test-ruleset.sh
+++ b/test-ruleset.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Run bash -x test-ruleset.sh RULESET_DIR [RULE_NAME|all] [short]
+#
 shopt -s extglob
 export PATH="$PATH:$PWD/node_modules/.bin:"
 DIFF_OPTS='-wubBEr --color'
@@ -7,7 +10,7 @@ BASEDIR="${1?Missing base directory}"; shift
 spectral_diff(){
     local rule="${1?Missing rule parameter}"
 
-    spectral lint tests/$rule-test.yml -r $rule.yml | \
+    spectral lint tests/$rule-{,[0-9]-}test.yml -r $rule.yml | \
         diff $DIFF_OPTS -I '^.*tests/.*-test.yml$' "tests/$rule-test.snapshot" -
 }
 
@@ -15,7 +18,7 @@ spectral_diff_display(){
     local rule="${1?Missing rule parameter}"
     local SED_IGNORE_LINES='s/^\s\+[0-9:]\+//g'
 
-    spectral lint tests/$rule-test.yml -r $rule.yml | \
+    spectral lint tests/$rule-{,[0-9]-}test.yml -r $rule.yml | \
     sed -e "$SED_IGNORE_LINES" | \
     diff $DIFF_OPTS -I '^.*tests/.*-test.yml$' \
         <(sed -e "$SED_IGNORE_LINES"  "tests/$rule-test.snapshot") -
@@ -47,12 +50,12 @@ case "$1" in
         if [ "$2" != "" ]; then
             RULE="$2"
             echo -n "Snapshotting rule $RULE.."
-            spectral lint tests/$RULE-test.yml -r $RULE.yml > tests/$RULE-test.snapshot
+            spectral lint tests/$RULE-{,[0-9]-}test.yml -r $RULE.yml > tests/$RULE-test.snapshot
             exit 0
         fi
         for RULE in $RULES; do
             echo -n "Snapshotting rule $RULE.."
-            spectral lint tests/$RULE-test.yml -r $RULE.yml > tests/$RULE-test.snapshot
+            spectral lint tests/$RULE-{,[0-9]-}test.yml -r $RULE.yml > tests/$RULE-test.snapshot
         done
         exit 0
         ;;


### PR DESCRIPTION
## This PR

- allows schemes with empty paths (eg. `paths: {}`) to support `components` only specifications.

## It's done

- using a schema check allowing `{}` and `{"/status": ...}`
- supporting multiple test files.