### PR TITLE
fix-clarify security rule

### DIFF
--- a/security/securitySchemes.yml
+++ b/security/securitySchemes.yml
@@ -3,7 +3,7 @@ rules:
     description: |-
       Your API should be protected by a `security` rule either at
       global or operation level.
-      Operations should be protected especially when they
+      All operations should be protected especially when they
       not safe (methods that do not alter the state of the server) 
       HTTP methods like `POST`, `PUT`, `PATCH` and `DELETE`.
       This is done with one or more non-empty `security` rules.

--- a/security/securitySchemes.yml
+++ b/security/securitySchemes.yml
@@ -3,8 +3,9 @@ rules:
     description: |-
       Your API should be protected by a `security` rule either at
       global or operation level.
-      Operations should be protected specially when they
-      are tied to non-idempotent HTTP methods like `POST`, `PUT`, `PATCH` and `DELETE`.
+      Operations should be protected especially when they
+      not safe (methods that do not alter the state of the server) 
+      HTTP methods like `POST`, `PUT`, `PATCH` and `DELETE`.
       This is done with one or more non-empty `security` rules.
 
       Security rules are defined in the `securityScheme` section.
@@ -61,10 +62,10 @@ rules:
             minProperties: 1
           minItems: 1
           type: array
-  sec-protection-non-idempotent:
+  sec-protection-unsafe:
     <<: *sec-protection-get
     message: >-
-      The following non-idempotent operation is not protected by a `security` rule: {{path}}
+      The following unsafe operation is not protected by a `security` rule: {{path}}
     severity: error
     given:
       - >-


### PR DESCRIPTION
Reworded description to clarify that the security is important for unsafe HTTP methods instead of non-idempotent. Also changed rule name to reflect the new description