### PR TITLE
Fixed selector to avoid false positives with properties named `patch`.

### DIFF
--- a/rules/patch.yml
+++ b/rules/patch.yml
@@ -71,7 +71,7 @@ rules:
       PATCH requires a non empty requestBody.
     severity: error
     given: >-
-      $..[patch]
+      $.paths.*.patch
     then:
     - field: requestBody
       function: defined


### PR DESCRIPTION
The selector `$..[patch]` triggers false positives with properties named `patch`. It should be changed to `$.paths.*.patch` to limit it to the paths.