### PR TITLE
Fix: #517. Use x-noqa to skip checks.

### DIFF
--- a/rules/problem.yml
+++ b/rules/problem.yml
@@ -29,7 +29,7 @@ rules:
       - oas3
     severity: error
     given: >-
-      $.paths.[*].responses[?(@property && @property.match(/^(4|5|default)/))].content.*~
+      $.paths.[*].responses[?(@property && @property.match(/^(4|5|default)/) && !@["x-noqa"] )].content.*~
     then:
       function: enumeration
       functionOptions:
@@ -68,7 +68,7 @@ rules:
     recommended: false
     # Search for 4xx, 5xx and default responses schema.
     given: >-
-      $.paths.[*].responses[?(@property && @property.match(/^(4|5|default)/))][[schema]]
+      $.paths.[*].responses[?(@property && @property.match(/^(4|5|default)/)  && !@["x-noqa"] )][[schema]]
     then:
       function: schema
       functionOptions:
@@ -130,7 +130,7 @@ rules:
     recommended: true
     # Search for 4xx, 5xx and default responses schema.
     given: >-
-      $..[responses][?(@property && @property.match(/^(4|5|default)/))][[schema]][properties].*~
+      $..[responses][?(@property && @property.match(/^(4|5|default)/)  && !@["x-noqa"] )][[schema]][properties].*~
     then:
       field: "@key"
       function: pattern

--- a/rules/tests/problem-test.snapshot
+++ b/rules/tests/problem-test.snapshot
@@ -3,8 +3,8 @@ OpenAPI 3.x detected
 /code/rules/tests/problem-test.yml
  21:30  error  use-problem-json-for-errors  Error responses should support RFC7807 in #/paths/~1ko-default-use-problem/get/responses/default/content/application~1json.  paths./ko-default-use-problem.get.responses.default.content.application/json
  27:25  error  use-problem-json-for-errors  Error responses should support RFC7807 in #/paths/~1ko-error-use-problem/get/responses/400/content/not~1problem.             paths./ko-error-use-problem.get.responses[400].content.not/problem
- 65:17   hint  hint-problem-schema          Error response doesn't seem to match RFC7807. Are you sure it is ok? #/components/schemas/ko_Problem/properties/message      components.schemas.ko_Problem.properties.message
- 67:14   hint  hint-problem-schema          Error response doesn't seem to match RFC7807. Are you sure it is ok? #/components/schemas/ko_Problem/properties/code         components.schemas.ko_Problem.properties.code
+ 82:17   hint  hint-problem-schema          Error response doesn't seem to match RFC7807. Are you sure it is ok? #/components/schemas/ko_Problem/properties/message      components.schemas.ko_Problem.properties.message
+ 84:14   hint  hint-problem-schema          Error response doesn't seem to match RFC7807. Are you sure it is ok? #/components/schemas/ko_Problem/properties/code         components.schemas.ko_Problem.properties.code
 
 ✖ 4 problems (2 errors, 0 warnings, 0 infos, 2 hints)
 

--- a/rules/tests/problem-test.yml
+++ b/rules/tests/problem-test.yml
@@ -47,7 +47,24 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ko_Problem'
-
+  /ok-skip-check-when-oauth2:
+    post:
+      responses:
+        "400":
+          x-noqa: RFC6902
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - invalid_client
+  /ok-regression:
+    post:
+      responses:
+        "400": {}
 components:
   schemas:
     Problem:


### PR DESCRIPTION
## This PR

Introduces `x-noqa` to skip some checks.