### PR TITLE
feat: make enum for numbers pass

### DIFF
--- a/security/numbers.yml
+++ b/security/numbers.yml
@@ -2,12 +2,12 @@ rules:
   sec-number-boundaries:
     description: |-
       Numeric values should be limited in size to mitigate resource exhaustion
-      using `maximum` and `minimum`.
+      using either `maximum` and `minimum` or `enum`.
 
       If you delegate input validation to a library or framework,
       be sure to test it thoroughly.
     message: >-
-      Schema of type number or integer must specify a maximum and a minimum. {{path}} {{error}}
+      Schema of type number or integer must specify a maximum and a minimum or enum. {{path}} {{error}}
     formats:
     - oas3
     severity: warn
@@ -18,7 +18,15 @@ rules:
     - >-
       $..[?(@.type=="integer")]
     then:
-    - field: maximum
-      function: defined
-    - field: minimum
-      function: defined
+      function: schema
+      functionOptions:
+        schema:
+          anyOf:
+          - type: object
+            required: [maximum, minimum]
+            not:
+              required: [enum]
+          - type: object
+            required: [enum]
+            not:
+              required: [maximum, minimum]

--- a/security/tests/numbers-test.snapshot
+++ b/security/tests/numbers-test.snapshot
@@ -1,11 +1,12 @@
 OpenAPI 3.x detected
 
 /code/security/tests/numbers-test.yml
-  4:15  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum. #/components/schemas/ko_Number `ko_Number.maximum` property should be defined                                                       components.schemas.ko_Number
-  6:21  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum. #/components/schemas/ko_Number_nomin `ko_Number_nomin.minimum` property should be defined                                           components.schemas.ko_Number_nomin
-  9:21  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum. #/components/schemas/ko_Number_nomax `ko_Number_nomax.maximum` property should be defined                                           components.schemas.ko_Number_nomax
- 26:17  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum. #/paths/~1number-ko-params/put/parameters/0/schema/oneOf/0 `[0].maximum` property should be defined                                 paths./number-ko-params.put.parameters[0].schema.oneOf[0]
- 42:19  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum. #/paths/~1number-ko-inline/put/requestBody/content/application~1json-patch+json/schema `schema.maximum` property should be defined  paths./number-ko-inline.put.requestBody.content.application/json-patch+json.schema
+  4:15  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum or enum. #/components/schemas/ko_Number `ko_Number` property should have required property `maximum`                                                       components.schemas.ko_Number
+  6:21  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum or enum. #/components/schemas/ko_Number_nomin `ko_Number_nomin` property should have required property `minimum`                                           components.schemas.ko_Number_nomin
+  9:21  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum or enum. #/components/schemas/ko_Number_nomax `ko_Number_nomax` property should have required property `maximum`                                           components.schemas.ko_Number_nomax
+ 12:22  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum or enum. #/components/schemas/ko_EnumAndMinMax `ko_EnumAndMinMax` property should not be valid                                                             components.schemas.ko_EnumAndMinMax
+ 34:17  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum or enum. #/paths/~1number-ko-params/put/parameters/0/schema/oneOf/0 `0` property should have required property `maximum`                                   paths./number-ko-params.put.parameters[0].schema.oneOf[0]
+ 50:19  warning  sec-number-boundaries  Schema of type number or integer must specify a maximum and a minimum or enum. #/paths/~1number-ko-inline/put/requestBody/content/application~1json-patch+json/schema `schema` property should have required property `maximum`  paths./number-ko-inline.put.requestBody.content.application/json-patch+json.schema
 
-✖ 5 problems (0 errors, 5 warnings, 0 infos, 0 hints)
+✖ 6 problems (0 errors, 6 warnings, 0 infos, 0 hints)
 

--- a/security/tests/numbers-test.yml
+++ b/security/tests/numbers-test.yml
@@ -9,10 +9,18 @@ components:
     ko_Number_nomax:
         type: number
         minimum: 1
+    ko_EnumAndMinMax:
+        type: number
+        enum: [3]
+        minimum: 8
+        maximum: 10
     Number:
         type: number
         minimum: 1
         maximum: 5
+    Enum:
+        type: number
+        enum: [3]
 openapi: 3.0.1
 paths:
   /number-ko-params:
@@ -56,6 +64,16 @@ paths:
                   $ref: '#/components/schemas/ko_Number_nomin'
                 nbad2:
                   $ref: '#/components/schemas/ko_Number_nomax'
+  /number-ko-enum-and-min-max:
+    put:
+      responses: {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                bad:
+                  $ref: '#/components/schemas/ko_EnumAndMinMax'
 
   /number-ok:
     put:
@@ -70,6 +88,19 @@ paths:
           application/json-patch+json:
             schema:
               $ref: '#/components/schemas/Number'
+  /enum-ok:
+    put:
+      responses: {}
+      parameters:
+        - name: n1
+          in: query
+          schema:
+            $ref: '#/components/schemas/Enum'
+      requestBody:
+        content:
+          application/json-patch+json:
+            schema:
+              $ref: '#/components/schemas/Enum'
 
 info:
   version: 1.0.0


### PR DESCRIPTION
Make `enum` for number pass even when there's no `minimum` and `maximum`.

Also, allow `enum` only if `minimum` and `maximum` are not set.